### PR TITLE
fix spawn in Windows OS

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -52,12 +52,20 @@ async function tagAndPush(modules, repository) {
     }
 }
 
+function adjustOsVersion(command) {
+    const isWin = process.platform === "win32";
+
+    if (isWin) command[0] = `${command[0]}.cmd`
+
+    return command            
+}
+
 async function processModule(filename) {
     try {
         const { repository = '', before_all = [], commands: modules = [] } = parse_yaml(filename, options.repository)
         if (!repository || !modules) return
 
-        for (const command of before_all) await execCommand(command, '--log')
+        for (const command of before_all) await execCommand(adjustOsVersion(command), '--log')
 
         console.log('\n')
 


### PR DESCRIPTION
In Windows OS, the spawn command is failing for the npx command triggered at first for compiling cds. 

Adding .cmd to the command fixes the issue.  
