### PR TITLE
add feature to build individual modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Version 0.2.5 - 2024-11-22
+
+### Added
+
+- Added feature to build modules individually
+
 ## Version 0.2.4 - 2024-10-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Build tool to containerize cloud applications.
      -h |  --help      get detailed usage information
      -v |  --version   get version of the package
      --repository      repository to push the images to
+     --modules         list the modules image has to be built for
 
  EXAMPLES
     ctz build.yaml
@@ -33,6 +34,8 @@ Build tool to containerize cloud applications.
     ctz build.yaml -l
     ctz build.yaml --push
     ctz build.yaml -p --log
+    ctz build.yaml --modules=mod1,mod2
+    ctz build.yaml --repository=docker.io/username
 ```
 
 ## Configuration
@@ -57,6 +60,7 @@ There are three ways to configure how to containerize a module:
       ```yaml
       modules:
       - name: bookshop-srv
+        tag: v1
         build-parameters:
           buildpack:
             type: nodejs
@@ -110,6 +114,7 @@ There are three ways to configure how to containerize a module:
     ```yaml
     modules:
     - name: bookshop-srv
+      tag: latest
       build-parameters:
         dockerfile: <path to a docker file>
     ```

--- a/lib/execute.js
+++ b/lib/execute.js
@@ -8,7 +8,8 @@ const args = process.argv.slice(3);
 const options = {
     push: args.includes('--push') || args.includes('-p'),
     log: args.includes('--log') || args.includes('-l'),
-    repository: args.find(arg => arg.startsWith('--repository'))?.split('=')[1] ?? ''
+    repository: args.find(arg => arg.startsWith('--repository'))?.split('=')[1] ?? '',
+    modules: args.find(arg => arg.startsWith('--modules'))?.split('=')[1].split(',') ?? []
 }
 
 function logMessage(message) {
@@ -51,7 +52,20 @@ async function tagAndPush(modules, repository) {
         await execCommand(module.pushCmd)
     }
 }
-
+async function executeModules(modules, repository, options) {
+    for (const module of modules) {
+        logMessage(`Containerising module ${module.name}`)
+        for (const buildCommand of module.buildCmd) {
+            await execCommand(buildCommand)
+        }
+    }
+    if (options.push) await tagAndPush(modules, repository)
+    else {
+        const answer = await ask("Do you wish to push the images to registry? (y/n): ")
+        if (answer === 'yes' || answer === 'y') await tagAndPush(modules, repository)
+        else console.log("Aborted")
+    }
+}
 async function processModule(filename) {
     try {
         const { repository = '', before_all = [], commands: modules = [] } = parse_yaml(filename, options.repository)
@@ -61,17 +75,13 @@ async function processModule(filename) {
 
         console.log('\n')
 
-        for (const module of modules) {
-            logMessage(`Containerising module ${module.name}`)
-            for (const buildCommand of module.buildCmd) {
-                await execCommand(buildCommand)
-            }
+        if(options.modules.length > 0) {
+            const filteredModules = modules.filter(module => options.modules.includes(module.name))
+            if(filteredModules.length === 0) throw new Error("No modules found with the given name")
+            await executeModules(filteredModules, repository, options);
         }
-        if (options.push) await tagAndPush(modules, repository)
         else {
-            const answer = await ask("Do you wish to push the images to registry? (y/n): ")
-            if (answer === 'yes' || answer === 'y') await tagAndPush(modules, repository)
-            else console.log("Aborted")
+            await executeModules(modules, repository, options);
         }
     }
     catch (e) {

--- a/lib/execute.js
+++ b/lib/execute.js
@@ -76,8 +76,12 @@ async function processModule(filename) {
         console.log('\n')
 
         if(options.modules.length > 0) {
-            const filteredModules = modules.filter(module => options.modules.includes(module.name))
-            if(filteredModules.length === 0) throw new Error("No modules found with the given name")
+            let filteredModules = [];
+            for(const moduleName of options.modules) {
+                const module = modules.find(module => module.name === moduleName)
+                if(!module) throw new Error(`No module found with the name ${moduleName}`);
+                filteredModules.push(module);
+            }
             await executeModules(filteredModules, repository, options);
         }
         else {


### PR DESCRIPTION
With reference to https://github.com/SAP/ctz/issues/16

Added functionality to build inidvidual modules.
This is accomplished by adding a new command --modules

Example: ctz build.yaml --modules=module1,module2

Have also updated the readme to specify about the modules command and to specify users that each module can have its own individual tag