### PR TITLE
Reserved keywords refer to official buildpacks now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Version 0.2.7 - 2025-02-12
+
+### Fixed
+
+- Reserved keywords refer to official buildpacks now
+
 ## Version 0.2.6 - 2025-01-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ There are three ways to configure how to containerize a module:
 
     |        Keyword    |      Parsed to                                               |
     |-------------------|--------------------------------------------------------------|
-    | *nodejs*          | gcr.io/paketo-buildpacks/nodejs                              |                
-    | *java*            | gcr.io/paketo-buildpacks/java                                |               
-    | *sap-machine*     | gcr.io/paketo-buildpacks/sap-machine                         |
-    | *executable-jar*  | gcr.io/paketo-buildpacks/executable-jar                      |
-    | *spring-boot*     | gcr.io/paketo-buildpacks/spring-boot                         |
-    | *syft*            | gcr.io/paketo-buildpacks/syft                                |
+    | *nodejs*          | paketo-buildpacks/nodejs                              |                
+    | *java*            | paketo-buildpacks/java                                |               
+    | *sap-machine*     | paketo-buildpacks/sap-machine                         |
+    | *executable-jar*  | paketo-buildpacks/executable-jar                      |
+    | *spring-boot*     | paketo-buildpacks/spring-boot                         |
+    | *syft*            | paketo-buildpacks/syft                                |
    
     </br>
 

--- a/lib/parse_yaml.js
+++ b/lib/parse_yaml.js
@@ -39,7 +39,7 @@ function processBuildpack(build_parameters, name, tag) {
     type = type ? type.split(',').map(type => {
         type = type.trim()
         if (buildpacks.has(type)) {
-            return `gcr.io/paketo-buildpacks/${type}`
+            return `paketo-buildpacks/${type}`
         } else {
             return type
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctz",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Build tool to containerize cloud applications",
   "homepage": "https://github.com/SAP/ctz",
   "keywords": [

--- a/test/expected.js
+++ b/test/expected.js
@@ -12,7 +12,7 @@ const desired_output = {
                "app",
                [
                   "--buildpack",
-                  "gcr.io/paketo-buildpacks/nodejs"
+                  "paketo-buildpacks/nodejs"
                ],
                "--builder",
                "paketobuildpacks/builder-jammy-base",

--- a/test/expected/build.json
+++ b/test/expected/build.json
@@ -12,7 +12,7 @@
                     "app",
                     [
                         "--buildpack",
-                        "gcr.io/paketo-buildpacks/nodejs"
+                        "paketo-buildpacks/nodejs"
                     ],
                     "--builder",
                     "paketobuildpacks/builder-jammy-base",
@@ -44,11 +44,11 @@
                     ".",
                     [
                         "--buildpack",
-                        "gcr.io/paketo-buildpacks/sap-machine"
+                        "paketo-buildpacks/sap-machine"
                     ],
                     [
                         "--buildpack",
-                        "gcr.io/paketo-buildpacks/java"
+                        "paketo-buildpacks/java"
                     ],
                     "--builder",
                     "paketobuildpacks/builder-jammy-buildpackless-base",
@@ -107,7 +107,7 @@
                     "build",
                     "bookshop-hana-deployer",
                     "--buildpack",
-                    "gcr.io/paketo-buildpacks/nodejs",
+                    "paketo-buildpacks/nodejs",
                     "--path",
                     "db",
                     "--builder",

--- a/test/expected/buildWithoutBuilder.json
+++ b/test/expected/buildWithoutBuilder.json
@@ -12,7 +12,7 @@
                     "app",
                     [
                         "--buildpack",
-                        "gcr.io/paketo-buildpacks/nodejs"
+                        "paketo-buildpacks/nodejs"
                     ],
                     "--env",
                     "BP_NODE_RUN_SCRIPTS=\"\""
@@ -65,7 +65,7 @@
                     "build",
                     "bookshop-hana-deployer",
                     "--buildpack",
-                    "gcr.io/paketo-buildpacks/nodejs",
+                    "paketo-buildpacks/nodejs",
                     "--path",
                     "db"
                 ]

--- a/test/expected/repositoryOption.json
+++ b/test/expected/repositoryOption.json
@@ -12,7 +12,7 @@
                     "app",
                     [
                         "--buildpack",
-                        "gcr.io/paketo-buildpacks/nodejs"
+                        "paketo-buildpacks/nodejs"
                     ],
                     "--builder",
                     "paketobuildpacks/builder-jammy-base",
@@ -44,11 +44,11 @@
                     ".",
                     [
                         "--buildpack",
-                        "gcr.io/paketo-buildpacks/sap-machine"
+                        "paketo-buildpacks/sap-machine"
                     ],
                     [
                         "--buildpack",
-                        "gcr.io/paketo-buildpacks/java"
+                        "paketo-buildpacks/java"
                     ],
                     "--builder",
                     "paketobuildpacks/builder-jammy-buildpackless-base",
@@ -107,7 +107,7 @@
                     "build",
                     "bookshop-hana-deployer",
                     "--buildpack",
-                    "gcr.io/paketo-buildpacks/nodejs",
+                    "paketo-buildpacks/nodejs",
                     "--path",
                     "db",
                     "--builder",

--- a/test/files/build.yaml
+++ b/test/files/build.yaml
@@ -28,4 +28,4 @@ modules:
   - name: bookshop-hana-deployer
     build-parameters:
       commands:
-        - 'pack build bookshop-hana-deployer --buildpack gcr.io/paketo-buildpacks/nodejs --path db --builder paketobuildpacks/builder-jammy-base'
+        - 'pack build bookshop-hana-deployer --buildpack paketo-buildpacks/nodejs --path db --builder paketobuildpacks/builder-jammy-base'

--- a/test/files/buildWithoutBuilder.yaml
+++ b/test/files/buildWithoutBuilder.yaml
@@ -17,4 +17,4 @@ modules:
   - name: bookshop-hana-deployer
     build-parameters:
       commands:
-        - 'pack build bookshop-hana-deployer --buildpack gcr.io/paketo-buildpacks/nodejs --path db'
+        - 'pack build bookshop-hana-deployer --buildpack paketo-buildpacks/nodejs --path db'


### PR DESCRIPTION
This PR changes the default buildpacks from `gcr.io/paketo-buildpacks/....` to `paketo-buildpacks/...`. Please refer to [this](https://github.com/SAP/ctz/issues/24) issue for more info. 